### PR TITLE
[Redux 1.0] Take `{ dispatch, getState }` instead of `next`

### DIFF
--- a/src/__tests__/promiseMiddleware-test.js
+++ b/src/__tests__/promiseMiddleware-test.js
@@ -4,14 +4,16 @@ import { spy } from 'sinon';
 function noop() {}
 
 describe('promiseMiddleware', () => {
+  let store;
   let baseDispatch;
   let dispatch;
   let foobar;
   let err;
 
   beforeEach(() => {
+    store = { dispatch: spy(), getState: spy() };
     baseDispatch = spy();
-    dispatch = promiseMiddleware(baseDispatch);
+    dispatch = promiseMiddleware(store)(baseDispatch);
     foobar = { foo: 'bar' };
     err = new Error();
   });

--- a/src/index.js
+++ b/src/index.js
@@ -4,8 +4,8 @@ function isPromise(val) {
   return val && typeof val.then === 'function';
 }
 
-export default function promiseMiddleware(next) {
-  return action => {
+export default function promiseMiddleware() {
+  return next => action => {
     if (!isFSA(action)) {
       return isPromise(action)
         ? action.then(next)


### PR DESCRIPTION
Updated the middleware to support the API in 1.0 RC: https://github.com/gaearon/redux/releases/tag/v1.0.0-rc.