### PR TITLE
Reject after dispatching error action.

### DIFF
--- a/src/__tests__/promiseMiddleware-test.js
+++ b/src/__tests__/promiseMiddleware-test.js
@@ -49,6 +49,11 @@ describe('promiseMiddleware', () => {
       payload: err,
       error: true
     });
+
+    await expect(dispatch({
+      type: 'ACTION_TYPE',
+      payload: Promise.reject(err)
+    })).to.eventually.be.rejectedWith(err);
   });
 
   it('handles promises', async () => {

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,10 @@ export default function promiseMiddleware({ dispatch }) {
     return isPromise(action.payload)
       ? action.payload.then(
           result => dispatch({ ...action, payload: result }),
-          error => dispatch({ ...action, payload: error, error: true })
+          error => {
+            dispatch({ ...action, payload: error, error: true });
+            return Promise.reject(error);
+          }
         )
       : next(action);
   };


### PR DESCRIPTION
The current behaviour might be intentional but I ran into an issue this evening where calling `then` on a dispatched promise would always result in being fulfilled:

```js
dispatch({
  type: 'ACTION_TYPE',
  payload: Promise.reject(err)
}).then(() => console.log('fulfilled'));

// Output: fulfilled
```

This PR will reject the error after dispatching the action.