### PR TITLE
Unpin flux-standard-action version

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "babel": "^5.6.14",
     "babel-core": "^5.6.15",
-    "babel-eslint": "^3.1.20",
+    "babel-eslint": "^5.0.0",
     "chai": "^3.0.0",
     "chai-as-promised": "^5.1.0",
     "eslint": "^0.24.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
     "sinon": "^1.15.4"
   },
   "dependencies": {
-    "flux-standard-action": "0.6.0"
+    "flux-standard-action": "^0.6.1"
   }
 }


### PR DESCRIPTION
I added [`^` operator](http://bytearcher.com/articles/semver-explained-why-theres-a-caret-in-my-package-json/) to the dependency version, because currently users cannot use redux-promise with [`flux-standard-action`](https://github.com/acdlite/flux-standard-action) v0.6.1 that includes [significant fixes](https://github.com/acdlite/flux-standard-action/pull/27).

Or, is there any explicit reason to pin `flux-standard-action` to v0.6.0?

====

Also I updated `babel-eslint` to v4.x (like https://github.com/acdlite/flux-standard-action/commit/a0de082100dbcf7d67bf128d60dbf1c12cb7eaab) to pass the test.
