### PR TITLE
Upgrade flux-standard-action to 0.6.1 to prevent "Unknown BABEL option"

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
     "sinon": "^1.15.4"
   },
   "dependencies": {
-    "flux-standard-action": "0.6.0"
+    "flux-standard-action": "^0.6.1",
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
     "sinon": "^1.15.4"
   },
   "dependencies": {
-    "flux-standard-action": "^0.6.1",
+    "flux-standard-action": "^0.6.1"
   }
 }


### PR DESCRIPTION
redux-promise needs to upgrade flux-standard-action to prevent build errors.  Please refer to the following issue:

https://github.com/acdlite/flux-standard-action/issues/24