### PR TITLE
bump to v0.6.0 for publishing #13

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-promise",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "description": "FSA-compliant promise middleware for Redux.",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Would be cool to get #13 onto npm. Just trying to make it easier.

Figured it warranted a pseudo-major bump since a major part of the interface has changed.