### PR TITLE
Throw the error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ export default function promiseMiddleware({ dispatch }) {
           result => dispatch({ ...action, payload: result }),
           error => {
             dispatch({ ...action, payload: error, error: true });
-            return Promise.reject(error);
+            throw error;
           }
         )
       : next(action);


### PR DESCRIPTION
There's no need to return a Rejected Promise inside a `#then` block.